### PR TITLE
Load shcore at runtime and fallback if newer DPI funcs are unavailable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ ffrunner.res: ffrunner.rc
 	$(WINDRES) ffrunner.rc -O coff -o ffrunner.res
 
 ffrunner.exe: ffrunner.res $(SRC) $(HDR)
-	$(CC) -std=c99 -pedantic -mwindows -Wl,--large-address-aware -O0 -g $(SRC) -o ffrunner.exe ffrunner.res -lwindowscodecs -lwininet -ldxgi -lshcore
+	$(CC) -std=c99 -pedantic -mwindows -Wl,--large-address-aware -O0 -g $(SRC) -o ffrunner.exe ffrunner.res -lwindowscodecs -lwininet -ldxgi
 
 gdbs:
 	wine /usr/share/win32/gdbserver.exe localhost:10000 ffrunner.exe

--- a/ffrunner.h
+++ b/ffrunner.h
@@ -35,6 +35,8 @@
 #define ARRLEN(x) (sizeof(x)/sizeof(*x))
 #define MIN(a, b) (a > b ? b : a)
 
+typedef HRESULT (WINAPI *SetProcessDpiAwarenessFunc)(PROCESS_DPI_AWARENESS awareness);
+
 typedef NPError     (OSCALL *NP_GetEntryPointsFuncOS)(NPPluginFuncs*);
 typedef NPError     (OSCALL *NP_InitializeFuncOS)(NPNetscapeFuncs*);
 typedef NPError     (OSCALL *NP_ShutdownFuncOS)(void);


### PR DESCRIPTION
This PR uses a different approach for setting DPI awareness that fixes support for Windows 7, 8, and 8.1. 

It does so by attempting to load shcore at runtime and on failure will revert back to the older SetProcessDPIAware() function with no arguments.

![vmplayer_2025-04-20_19-20-18](https://github.com/user-attachments/assets/aa2abf77-bb12-4a23-8430-6966714644c2)
